### PR TITLE
FIX: Restore missing delimiter error message

### DIFF
--- a/nibabel/cifti2/cifti2.py
+++ b/nibabel/cifti2/cifti2.py
@@ -287,7 +287,7 @@ class Cifti2Label(xml.XmlSerializable):
         return (self.red, self.green, self.blue, self.alpha)
 
     def _to_xml_element(self):
-        if self.label is '':
+        if self.label == '':
             raise Cifti2HeaderError('Label needs a name')
         try:
             v = int(self.key)

--- a/nibabel/streamlines/tck.py
+++ b/nibabel/streamlines/tck.py
@@ -432,7 +432,11 @@ class TckFile(TractogramFile):
                 leftover = coords[begin:]
 
             if not (leftover.shape == (1, 3) and np.isinf(leftover).all()):
-                raise DataError("Expecting end-of-file marker 'inf inf inf'")
+                if n_streams == 0:
+                    msg = "Cannot find a streamline delimiter. This file might be corrupted."
+                else:
+                    msg = "Expecting end-of-file marker 'inf inf inf'"
+                raise DataError(msg)
 
             # In case the 'count' field was not provided.
             header[Field.NB_STREAMLINES] = n_streams


### PR DESCRIPTION
Also includes a couple style issues, mostly just reducing needless lines changed to keep the final merge commit succinct. Also a style issue that is apparently just now getting flagged by flake8 in an unrelated file.